### PR TITLE
GH-3 fix content after ellipsis

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dynamic-middle-ellipsis/core",
-	"version": "1.0.0",
+	"version": "1.0.1",
 	"type": "module",
 	"description": "Framework-agnostic text truncation with middle ellipsis - core utilities",
 	"author": "Lalit Rana",

--- a/packages/core/src/truncate-text.ts
+++ b/packages/core/src/truncate-text.ts
@@ -57,13 +57,13 @@ const truncateText = ({
 		firstHalf += originalText[i];
 
 		remainingWidth -= getCharacterWidth(
-			originalText.at(i - 1) as string,
+			originalText[originalTextLength - i - 1],
 			fontFamily,
 			fontSize,
 		);
 
 		if (remainingWidth < 0) break;
-		secondHalf = originalText.at(i - 1) + secondHalf;
+		secondHalf = originalText[originalTextLength - i - 1] + secondHalf;
 	}
 
 	return firstHalf + ellipsisSymbol + secondHalf;


### PR DESCRIPTION
issue: #3 

We were not going in reverse to pick characters from the end. But rather picking character from the start itself.

Now we are correctly picking characters in reverse order from the end of string.

---

Also updated patch version for package.