### PR TITLE
GH-8 merge props passed correctly

### DIFF
--- a/packages/react/src/Span.tsx
+++ b/packages/react/src/Span.tsx
@@ -41,10 +41,10 @@ export const Span = ({
 	return (
 		// biome-ignore lint/a11y/useAriaPropsSupportedByRole: we need to use aria-label for accessibility
 		<span
-			ref={nodeRef}
-			{...rest}
-			style={{ wordBreak: "break-all" }}
 			aria-label={children}
+			{...rest}
+			ref={nodeRef}
+			style={{ ...(rest?.style || {}), wordBreak: "break-all" }}
 		>
 			{"\u00A0"}
 		</span>


### PR DESCRIPTION
Merge passed props in a way that does not override `ref` and `style.wordBreak` key properties.